### PR TITLE
Improve zip performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "dbf": "0.1.4",
-    "jszip": "2.5.0"
+    "jszip": "^3.2.2"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/src/poly.js
+++ b/src/poly.js
@@ -166,7 +166,8 @@ function justCoords(coords, l) {
     if (l === undefined) l = [];
     if (typeof coords[0][0] == 'object') {
         return coords.reduce(function(memo, c) {
-            return memo.concat(justCoords(c));
+            Array.prototype.push.apply(memo, justCoords(c));
+            return memo;
         }, l);
     } else {
         return coords;

--- a/src/zip.js
+++ b/src/zip.js
@@ -46,11 +46,14 @@ module.exports = function(gj, options) {
         }
     });
 
-    var generateOptions = { compression:'STORE' };
+    var generateOptions = { 
+        compression:'STORE', 
+        type: (options && options.type) || 'base64'
+    };
 
     if (!process.browser) {
       generateOptions.type = 'nodebuffer';
     }
 
-    return zip.generate(generateOptions);
+    return zip.generateAsync(generateOptions);
 };


### PR DESCRIPTION
- Replace `Array.concat` with `Array.push` to save time and memory
- Upgrade JSZip and use `blob` output instead of `base64` output