### PR TITLE
Multipoint fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Or in a browser
 
 * Requires a capable fancy modern browser with [Typed Arrays](http://caniuse.com/#feat=typedarrays)
   support
-* Supported Geojson Geometries: Point, LineString, MultiLineString, Polygon
-* Unsupported Geojson Geometries: MultiPoint, MultiPolygon
+* Supported Geojson Geometries: Point, LineString, MultiLineString, MultiPoint, Polygon
+* Unsupported Geojson Geometries: MultiPolygon
 * Tabular-style properties export with Shapefile's field name length limit
 * Uses jsZip for ZIP files, but [compression is buggy](https://github.com/Stuk/jszip/issues/53) so it uses STORE instead of DEFLATE.
 
@@ -77,7 +77,7 @@ converts convertible features into Shapefiles and triggers a download.
 
 Given data, an array of objects for each row of data, geometry, the OGC standard
 geometry type (like `POINT`), geometries, a list of geometries as bare coordinate
-arrays, generate a shapfile and call the callback with `err` and an object with
+arrays, generate a shapefile and call the callback with `err` and an object with
 
 ```js
 {

--- a/example/zip/multiPoint.js
+++ b/example/zip/multiPoint.js
@@ -4,7 +4,7 @@ node example/zip/multiPoint.js
 var zip = require('../../src/zip'),
     fs = require('fs');
 
-var multiPointGeojson = require('../../test/geojson/MultiPoint-2d-single.json');
+var multiPointGeojson = require('../../test/geojson/MultiPoint-2d-multiple.json');
 
 var zipOptions = {
     types: {

--- a/example/zip/multiPointZ.js
+++ b/example/zip/multiPointZ.js
@@ -1,11 +1,10 @@
 /*
 node example/zip/multiPointZ.js
 */
-// ! broken
 var zip = require('../../src/zip'),
     fs = require('fs');
 
-var multiPointZGeojson = require('../../test/geojson/MultiPoint-3d-single.json');
+var multiPointZGeojson = require('../../test/geojson/MultiPoint-3d-multiple.json');
 
 var zipOptions = {
     types: {

--- a/example/zip/zip.js
+++ b/example/zip/zip.js
@@ -36,12 +36,16 @@ var lineString2dSingleGeojson = require('../../test/geojson/LineString-2d-single
 var lineString3dMultipleGeojson = require('../../test/geojson/LineString-3d-multiple.json');
 var lineString3dSingleGeojson = require('../../test/geojson/LineString-3d-single.json');
 
+// edge case worth testing
 var multiLineString2dMultipleGeojson = require('../../test/geojson/MultiLineString-2d-multiple.json');
 var multiLineString3dMultipleGeojson = require('../../test/geojson/MultiLineString-3d-multiple.json');
 
-// These examples are commented out, as MultiPoint and MultiPolygon are currently not supported
-// var multiPoint2dSingleGeojson = require('../../test/geojson/MultiPoint-2d-single.json');
-// var multiPoint3dSingleGeojson = require('../../test/geojson/MultiPoint-3d-single.json');
+var multiPoint2dMultipleGeojson = require('../../test/geojson/MultiPoint-2d-multiple.json');
+var multiPoint2dSingleGeojson = require('../../test/geojson/MultiPoint-2d-single.json');
+var multiPoint3dMultipleGeojson = require('../../test/geojson/MultiPoint-3d-multiple.json');
+var multiPoint3dSingleGeojson = require('../../test/geojson/MultiPoint-3d-single.json');
+
+// These examples are commented out, as MultiPolygons are currently not supported
 // var multiPolygon2dSingleGeojson = require('../../test/geojson/MultiPolygon-2d-single.json');
 // var multiPolygon3dSingleGeojson = require('../../test/geojson/MultiPolygon-3d-single.json');
 
@@ -63,12 +67,16 @@ geojsonZipHelper(lineString2dSingleGeojson, 'LineString2dSingle.shp.zip');
 geojsonZipHelper(lineString3dMultipleGeojson, 'LineString3dMultiple.shp.zip');
 geojsonZipHelper(lineString3dSingleGeojson, 'LineString3dSingle.shp.zip');
 
+// edge case worth testing
 geojsonZipHelper(multiLineString2dMultipleGeojson, 'MultiLineString2dMultiple.shp.zip');
 geojsonZipHelper(multiLineString3dMultipleGeojson, 'MultiLineString3dMultiple.shp.zip');
 
-// These examples are commented out, as MultiPoint and MultiPolygon are currently not supported
-// geojsonZipHelper(multiPoint2dSingleGeojson, 'MultiPoint2dSingle.shp.zip');
-// geojsonZipHelper(multiPoint3dSingleGeojson, 'MultiPoint3dSingleString.shp.zip');
+geojsonZipHelper(multiPoint2dMultipleGeojson, 'MultiPoint2dMultiple.shp.zip');
+geojsonZipHelper(multiPoint2dSingleGeojson, 'MultiPoint2dSingle.shp.zip');
+geojsonZipHelper(multiPoint3dMultipleGeojson, 'MultiPoint3dMultiple.shp.zip');
+geojsonZipHelper(multiPoint3dSingleGeojson, 'MultiPoint3dSingle.shp.zip');
+
+// These examples are commented out, as MultiPolygons are currently not supported
 // geojsonZipHelper(multiPolygon2dSingleGeojson, 'MultiPolygon2dSingleString.shp.zip');
 // geojsonZipHelper(multiPolygon3dSingleGeojson, 'MultiPolygon3dSingleString.shp.zip');
 

--- a/src/multipoint.js
+++ b/src/multipoint.js
@@ -1,125 +1,129 @@
-var ext = require('./extent');
-var types = require('./types');
+var ext = require("./extent");
+var types = require("./types");
 
-module.exports.write = function writePoints(coordinates, extent, shpView, shxView, TYPE) {
+module.exports.write = function writePoints(
+  coordinates,
+  extent,
+  shpView,
+  shxView,
+  TYPE
+) {
+  var shpI = 0,
+    shxI = 0;
+  (shxOffset = 100), (is3D = TYPE === types.geometries.MULTIPOINTZ);
 
-    var shpI = 0,
-        shxI = 0;
-        shxOffset = 100,
-        is3D = TYPE === types.geometries.MULTIPOINTZ;
+  coordinates.forEach(writeMultipoint);
 
-    coordinates.forEach(writeMultipoint);
-
-    function writeMultipoint(coords, i) {
-        // Length of multipoint record
-        var contentLength = 40 + (coords.length * 16);
-        if (is3D) {
-            contentLength += 32 + (coords.length * 16);
-        }
-        var totalLength = contentLength + 8;
-
-        var featureExtent = coords.reduce(function(extent, c) {
-            return ext.enlarge(extent, c);
-        }, ext.blank());
-
-        // Write entry to index file.
-        shxView.setInt32(shxI, shxOffset / 2); // Offset in shx file.
-        shxView.setInt32(shxI + 4, totalLength / 2); // Record length.
-        shxI += 8;
-        shxOffset += totalLength;
-
-        // Write record to shape file.
-        shpView.setInt32(shpI, i); // Record number
-        shpView.setInt32(shpI + 4, contentLength / 2); // Record length (in 16 bit words);
-        shpView.setInt32(shpI + 8, TYPE, true); // Record type. MULTIPOINT=8,MULTIPOINTZ=18
-        shpView.setFloat64(shpI + 12, featureExtent.xmin, true); // Bounding box.
-        shpView.setFloat64(shpI + 20, featureExtent.ymin, true);
-        shpView.setFloat64(shpI + 28, featureExtent.xmax, true);
-        shpView.setFloat64(shpI + 36, featureExtent.ymax, true);
-        shpView.setInt32(shpI + 44, coords.length, true); // Number of points.
-        shpI += 48;
-
-        // Write points.
-        var zMin = Number.MAX_VALUE;
-        var zMax = -Number.MAX_VALUE;
-        var mMin = Number.MAX_VALUE;
-        var mMax = -Number.MAX_VALUE;
-        coords.forEach(function(p, i) {
-            if ((coords[2] || 0) < zMin) {
-                zMin = coords[2] || 0;
-            }
-
-            if ((coords[2] || 0) > zMax) {
-                zMax = coords[2] || 0;
-            }
-
-            if ((coords[3] || 0) < mMin) {
-                mMin = coords[3] || 0;
-            }
-
-            if ((coords[3] || 0) > mMax) {
-                mMax = coords[3] || 0;
-            }
-
-            shpView.setFloat64(shpI, p[0], true); // X
-            shpView.setFloat64(shpI + 8, p[1], true); // Y
-            shpI += 16;
-        });
-
-        if (is3D) {
-            // Write z value range
-            shpView.setFloat64(shpI, zMin, true);
-            shpView.setFloat64(shpI + 8, zMax, true);
-            shpI += 16
-
-            // Write z values.
-            coords.forEach(function(p, i) {
-                shpView.setFloat64(shpI, p[2] || 0, true);
-                shpI += 8;
-            });
-
-            // Write m value range.
-            shpView.setFloat64(shpI, mMin, true);
-            shpView.setFloat64(shpI + 8, mMax, true);
-            shpI += 16;
-
-            // Write m values;
-            coords.forEach(function(p, i) {
-                shpView.setFloat64(shpI, p[3] || 0, true);
-                shpI += 8;
-            });
-        }
+  function writeMultipoint(coords, i) {
+    // Length of multipoint record
+    var contentLength = 40 + coords.length * 16;
+    if (is3D) {
+      contentLength += 32 + coords.length * 16;
     }
+    var totalLength = contentLength + 8;
+
+    var featureExtent = coords.reduce(function (extent, c) {
+      return ext.enlarge(extent, c);
+    }, ext.blank());
+
+    // Write entry to index file.
+    shxView.setInt32(shxI, shxOffset / 2); // Offset in shx file.
+    shxView.setInt32(shxI + 4, totalLength / 2); // Record length.
+    shxI += 8;
+    shxOffset += totalLength;
+
+    // Write record to shape file.
+    shpView.setInt32(shpI, i); // Record number
+    shpView.setInt32(shpI + 4, contentLength / 2); // Record length (in 16 bit words);
+    shpView.setInt32(shpI + 8, TYPE, true); // Record type. MULTIPOINT=8,MULTIPOINTZ=18
+    shpView.setFloat64(shpI + 12, featureExtent.xmin, true); // Bounding box.
+    shpView.setFloat64(shpI + 20, featureExtent.ymin, true);
+    shpView.setFloat64(shpI + 28, featureExtent.xmax, true);
+    shpView.setFloat64(shpI + 36, featureExtent.ymax, true);
+    shpView.setInt32(shpI + 44, coords.length, true); // Number of points.
+    shpI += 48;
+
+    // Write points.
+    var zMin = Number.MAX_VALUE;
+    var zMax = -Number.MAX_VALUE;
+    var mMin = Number.MAX_VALUE;
+    var mMax = -Number.MAX_VALUE;
+    coords.forEach(function (p, i) {
+      if ((coords[2] || 0) < zMin) {
+        zMin = coords[2] || 0;
+      }
+
+      if ((coords[2] || 0) > zMax) {
+        zMax = coords[2] || 0;
+      }
+
+      if ((coords[3] || 0) < mMin) {
+        mMin = coords[3] || 0;
+      }
+
+      if ((coords[3] || 0) > mMax) {
+        mMax = coords[3] || 0;
+      }
+
+      shpView.setFloat64(shpI, p[0], true); // X
+      shpView.setFloat64(shpI + 8, p[1], true); // Y
+      shpI += 16;
+    });
+
+    if (is3D) {
+      // Write z value range
+      shpView.setFloat64(shpI, zMin, true);
+      shpView.setFloat64(shpI + 8, zMax, true);
+      shpI += 16;
+
+      // Write z values.
+      coords.forEach(function (p, i) {
+        shpView.setFloat64(shpI, p[2] || 0, true);
+        shpI += 8;
+      });
+
+      // Write m value range.
+      shpView.setFloat64(shpI, mMin, true);
+      shpView.setFloat64(shpI + 8, mMax, true);
+      shpI += 16;
+
+      // Write m values;
+      coords.forEach(function (p, i) {
+        shpView.setFloat64(shpI, p[3] || 0, true);
+        shpI += 8;
+      });
+    }
+  }
 };
 
-module.exports.extent = function(coordinates) {
-    var flattented = justCoords(coordinates);
-    return flattented.reduce(function(extent, coords) {
-        return ext.enlarge(extent, coords);
-    }, ext.blank());
+module.exports.extent = function (coordinates) {
+  var flattened = justCoords(coordinates);
+  return flattened.reduce(function (extent, coords) {
+    return ext.enlarge(extent, coords);
+  }, ext.blank());
 };
 
 module.exports.parts = function parts(geometries, TYPE) {
-    return geometries.length;
+  return geometries.length;
 };
 
-module.exports.shxLength = function(coordinates) {
-    return coordinates.length * 8;
+module.exports.shxLength = function (coordinates) {
+  return coordinates.length * 8;
 };
 
-module.exports.shpLength = function(coordinates, TYPE) {
-    var flattented = justCoords(coordinates);
-    var length = coordinates.length * 48 + flattented.length * 16;
-    if (TYPE === types.geometries.MULTIPOINTZ) {
-        length += 32 + (flattented.length * 16);
-    }
+module.exports.shpLength = function (coordinates, TYPE) {
+  var flattened = justCoords(coordinates);
+  var length = coordinates.length * 48 + flattened.length * 16;
+  if (TYPE === types.geometries.MULTIPOINTZ) {
+    length += 32 + flattened.length * 16;
+  }
 
-    return length;
+  return length;
 };
 
 function justCoords(coords) {
-    var points = [];
-    return coords.reduce(function(agg, c) {
-        return agg.concat(c);
-    }, points);
+  var points = [];
+  return coords.reduce(function (agg, c) {
+    return agg.concat(c);
+  }, points);
 }

--- a/src/multipoint.js
+++ b/src/multipoint.js
@@ -14,6 +14,7 @@ module.exports.write = function writePoints(
 
   coordinates.forEach(writeMultipoint);
 
+  // write a single Multipoint Record
   function writeMultipoint(coords, i) {
     // Length of multipoint record
     var contentLength = 40 + coords.length * 16;
@@ -111,11 +112,14 @@ module.exports.shxLength = function (coordinates) {
   return coordinates.length * 8;
 };
 
+// coordinates.length: number of records
+// flattened.length: total number of points in all records
 module.exports.shpLength = function (coordinates, TYPE) {
   var flattened = justCoords(coordinates);
   var length = coordinates.length * 48 + flattened.length * 16;
+
   if (TYPE === types.geometries.MULTIPOINTZ) {
-    length += 32 + flattened.length * 16;
+    length += coordinates.length * 32 + flattened.length * 16;
   }
 
   return length;

--- a/src/poly.js
+++ b/src/poly.js
@@ -18,6 +18,7 @@ module.exports.write = function writePolyRecord(
     // call for every polygon/polyline feature
     geometries.forEach(writePoly);
 
+    // write a single Polygon Record
     function writePoly(coordinates, i) {
         var flattened = justCoords(coordinates),
             noParts =

--- a/test/geojson/MultiPoint-2d-multiple.json
+++ b/test/geojson/MultiPoint-2d-multiple.json
@@ -1,0 +1,43 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "MultiPoint-Name-1"
+        },
+        "geometry": {
+          "type": "MultiPoint",
+          "coordinates": [
+            [
+                2.2945,
+                48.829
+            ],
+            [
+                2.3125,
+                48.854
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "MultiPoint-Name-2"
+        },
+        "geometry": {
+          "type": "MultiPoint",
+          "coordinates": [
+            [
+                2.3,
+                48.86
+            ],
+            [
+                2.31,
+                48.85
+            ]
+          ]
+        }
+      }
+    ]
+  }

--- a/test/geojson/MultiPoint-3d-multiple.json
+++ b/test/geojson/MultiPoint-3d-multiple.json
@@ -1,0 +1,47 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "MultiPointZ-Name-1"
+        },
+        "geometry": {
+          "type": "MultiPoint",
+          "coordinates": [
+            [
+                2.2945,
+                48.858,
+                75.0
+            ],
+            [
+                2.3125,
+                48.854,
+                5.0
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "MultiPointZ-Name-2"
+        },
+        "geometry": {
+          "type": "MultiPoint",
+          "coordinates": [
+            [
+                2.29,
+                48.85,
+                25.0
+            ],
+            [
+                2.31,
+                48.81,
+                35.0
+            ]
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
#### Problem

Multipoint geojson files were failing to convert to SHP files. This was due to their shpLength method returning a value that is too small.

#### Solution

Fix the shpLength method. Add additional examples and comments.

#### Testing

Run `node example/zip/multiPoint.js` and make sure the file is generated successfully. 
Update the path to point to:
`MultiPoint-2d-multiple.json`
`MultiPoint-2d-single.json`
`MultiPoint-3d-multiple.json`
`MultiPoint-3d-single.json`
Confirm these files all generate successfully and can be uploaded into ArcGIS Pro, QGIS, and Civil 3D.

Run `node example/zip/zip.js` and make sure nothing fails.
